### PR TITLE
Add x_offset

### DIFF
--- a/config.ini
+++ b/config.ini
@@ -21,6 +21,10 @@
 # Allowed values range from 0 (top) to 1.0 (bottom).
 ;y-offset = 0.75
 
+# A relative offset of the notification to the left of the screen.
+# Allowed values range from 0 (left) to 1.0 (right).
+;x-offset = 0.5
+
 # The border radius of the notification in px.
 ;border-radius = 16
 

--- a/src/avizo_client.vala
+++ b/src/avizo_client.vala
@@ -13,6 +13,7 @@ interface AvizoService : GLib.Object
 	public abstract int border_width { owned get; set; }
 	public abstract int padding { owned get; set; }
 	public abstract double y_offset { owned get; set; }
+	public abstract double x_offset { owned get; set; }
 	public abstract int block_height { owned get; set; }
 	public abstract int block_spacing { owned get; set; }
 	public abstract int block_count { owned get; set; }
@@ -41,6 +42,7 @@ public class AvizoClient : GLib.Application
 	private static int _width = 248;
 	private static int _height = 232;
 	private static double _y_offset = 0.75;
+	private static double _x_offset = 0.50;
 	private static int _padding = 24;
 	private static int _border_radius = 16;
 	private static int _border_width = 1;
@@ -68,6 +70,7 @@ public class AvizoClient : GLib.Application
 		{ "width", 0, 0, OptionArg.INT, ref _width, "Sets the width of the notification", "INT" },
 		{ "height", 0, 0, OptionArg.INT, ref _height, "Sets the height of the notification", "INT" },
 		{ "y-offset", 0, 0, OptionArg.DOUBLE, ref _y_offset, "Sets relative offset of the notification to the top of the screen, allowed values range from 0 (top) to 1.0 (bottom)", "DOUBLE" },
+		{ "x-offset", 0, 0, OptionArg.DOUBLE, ref _x_offset, "Sets relative offset of the notification to the left of the screen, allowed values range from 0 (left) to 1.0 (right)", "DOUBLE" },
 		{ "padding", 0, 0, OptionArg.INT, ref _padding, "Sets the inner padding of the notification", "INT" },
 		{ "border-radius", 0, 0, OptionArg.INT, ref _border_radius, "Sets the border radius of the notification in px", "INT" },
 		{ "border-width", 0, 0, OptionArg.INT, ref _border_width, "Sets the border width of the notification in px", "INT" },
@@ -183,6 +186,7 @@ public class AvizoClient : GLib.Application
 		_service.height = _height;
 		_service.padding = _padding;
 		_service.y_offset = _y_offset;
+		_service.x_offset = _x_offset;
 		_service.border_radius = _border_radius;
 		_service.border_width = _border_width;
 		_service.block_height = _block_height;

--- a/src/avizo_service.vala
+++ b/src/avizo_service.vala
@@ -297,6 +297,7 @@ public class AvizoService : GLib.Object
 	public int height { get; set; default = 232; }
 	public int padding { get; set; default = 24; }
 	public double y_offset { get; set; default = 0.75; }
+	public double x_offset { get; set; default = 0.50; }
 	public int border_radius { get; set; default = 16; }
 	public int border_width { get; set; default = 1; }
 	public int block_height { get; set; default = 10; }
@@ -350,7 +351,7 @@ public class AvizoService : GLib.Object
 
 			if (_open_timeouts == 0)
 			{
-				for (int i = 0; i < monitors; i++) 
+				for (int i = 0; i < monitors; i++)
 				{
 					var window = _windows.index(i);
 					if (window != null)
@@ -378,6 +379,7 @@ public class AvizoService : GLib.Object
 			GtkLayerShell.init_for_window(window);
 			GtkLayerShell.set_layer(window, GtkLayerShell.Layer.OVERLAY);
 			GtkLayerShell.set_anchor(window, GtkLayerShell.Edge.TOP, true);
+			GtkLayerShell.set_anchor(window, GtkLayerShell.Edge.LEFT, true);
 			GtkLayerShell.set_namespace(window, "avizo");
 			GtkLayerShell.set_exclusive_zone(window, -1);
 #if HAVE_LATEST_GTK_LAYER_SHELL
@@ -392,19 +394,22 @@ public class AvizoService : GLib.Object
 
 	private void show_window(AvizoWindow window, Gdk.Monitor monitor)
 	{
-		var margin = (int) Math.lround((monitor.workarea.height - height) * y_offset);
+		var margin_top = (int) Math.lround((monitor.workarea.height - height) * y_offset);
+		var margin_left = (int) Math.lround((monitor.workarea.width - width) * x_offset);
 
 		if (is_wayland(monitor.get_display()))
 		{
 			GtkLayerShell.set_monitor(window, monitor);
-			GtkLayerShell.set_margin(window, GtkLayerShell.Edge.TOP, margin);
+			GtkLayerShell.set_margin(window, GtkLayerShell.Edge.TOP, margin_top);
+			GtkLayerShell.set_margin(window, GtkLayerShell.Edge.LEFT, margin_left);
 		}
 		else
 		{
-			int x, _y;
+			int x, y;
 			window.set_position(Gtk.WindowPosition.CENTER);
-			window.get_position(out x, out _y);
-			window.move(x, margin);
+			window.get_position(out x, out y);
+			window.move(x, margin_top);
+			window.move(y, margin_left);
 			window.set_type_hint(Gdk.WindowTypeHint.NOTIFICATION);
 			window.set_accept_focus(false);
 		}


### PR DESCRIPTION
Adds the `x_offset` config option to set the horizontal position of the client

I cloned everything `y_offset` related and added
```
GtkLayerShell.set_anchor(window, GtkLayerShell.Edge.LEFT, true);
```

Fulfills the feature request in #70 