### PR TITLE
fix options of lightctl

### DIFF
--- a/lightctl
+++ b/lightctl
@@ -51,7 +51,7 @@ dev=
 optind=1
 dark=0
 monitor=-1
-while getopts 'e:D:hM:d' OPT; do
+while getopts ':e:D:hM:d' OPT; do
 	case "$OPT" in
 		e) exp=$OPTARG;;
 		D) dev=$OPTARG;;

--- a/lightctl
+++ b/lightctl
@@ -51,7 +51,7 @@ dev=
 optind=1
 dark=0
 monitor=-1
-while getopts ':e:D:h:M:d' OPT; do
+while getopts 'e:D:hM:d' OPT; do
 	case "$OPT" in
 		e) exp=$OPTARG;;
 		D) dev=$OPTARG;;


### PR DESCRIPTION
From the man page of [getopts](https://www.man7.org/linux/man-pages/man1/getopts.1p.html):
```
optstring A string containing the option characters recognized by
                 the utility invoking getopts.  If a character is
                 followed by a <colon>, the option shall be expected to
                 have an argument, which should be supplied as a
                 separate argument
```

this is why `lightctl -h` doesn't work but `lightctl -hh` works. Also I am not sure why there is a colon before e but if I understand the man page right there is literally no gain by doing it so I removed it.